### PR TITLE
Configure DB for AWS deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # QA 맛집 지도
 
-이 프로젝트는 FastAPI와 SQLite를 사용하여 QA팀에서 검증한 맛집 정보를 관리하는 내부용 웹 API 입니다.
+이 프로젝트는 FastAPI를 이용한 내부용 맛집 리뷰 API입니다. 기본적으로 SQLite를 사용하지만 `DATABASE_URL` 환경 변수를 지정하면 외부 데이터베이스를 사용할 수 있습니다. AWS Lightsail 배포와 AWS RDS 연결을 염두에 두고 있습니다.
 
 ## 실행 방법
 
@@ -8,12 +8,15 @@
 
 ```bash
 pip install fastapi uvicorn sqlalchemy pydantic
+# 사용하려는 DB 드라이버도 함께 설치합니다. (예: psycopg2-binary, PyMySQL 등)
 ```
 
 2. 서버 실행
 
 ```bash
-uvicorn app.main:app --reload
+uvicorn app.main:app --host 0.0.0.0 --port 80
 ```
+
+서버 실행 전 `DATABASE_URL` 환경 변수에 AWS RDS 연결 문자열을 설정합니다. 환경 변수가 없으면 로컬 SQLite 데이터베이스(`app.db`)를 사용합니다.
 
 실행 후 `http://localhost:8000/docs` 에서 Swagger UI를 통해 API를 확인할 수 있습니다.

--- a/app/database.py
+++ b/app/database.py
@@ -1,11 +1,16 @@
+import os
+
 from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 
-SQLALCHEMY_DATABASE_URL = "sqlite:///./app.db"
 
-engine = create_engine(
-    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
-)
+SQLALCHEMY_DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./app.db")
+
+connect_args = {"check_same_thread": False} if SQLALCHEMY_DATABASE_URL.startswith(
+    "sqlite"
+) else {}
+
+engine = create_engine(SQLALCHEMY_DATABASE_URL, connect_args=connect_args)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 Base = declarative_base()


### PR DESCRIPTION
## Summary
- make SQLAlchemy DB URL configurable via `DATABASE_URL`
- document AWS Lightsail + RDS deployment steps

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684cd5f900508329b697db4a87f227bd